### PR TITLE
Add basic coaster track and car entities

### DIFF
--- a/assets/art/placeholder.txt
+++ b/assets/art/placeholder.txt
@@ -1,0 +1,1 @@
+i put this here so its recognised as a path

--- a/assets/music/placeholder.txt
+++ b/assets/music/placeholder.txt
@@ -1,0 +1,1 @@
+i put this here so its recognised as a path

--- a/assets/sfx/placeholder.txt
+++ b/assets/sfx/placeholder.txt
@@ -1,0 +1,1 @@
+i put this here so its recognised as a path

--- a/project.godot
+++ b/project.godot
@@ -11,9 +11,15 @@ config_version=5
 [application]
 
 config/name="New Game Project"
+run/main_scene="uid://crtg2aujnc5rl"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
 
 [display]
 
 window/stretch/mode="canvas_items"
+
+[layer_names]
+
+2d_physics/layer_5="track_start"
+2d_physics/layer_6="track_end"

--- a/scenes/entities/car.gd
+++ b/scenes/entities/car.gd
@@ -1,0 +1,17 @@
+extends PathFollow2D
+class_name Car
+
+var track_attached:TrackPart
+var speed:float
+
+func _ready() -> void:
+	speed = track_attached.track_speed
+
+func _process(delta: float) -> void:
+	progress_ratio += 0.2 * delta * speed
+	if progress_ratio >= 0.99:
+		if track_attached.track_right and track_attached.track_cooldown == false:
+			track_attached.pass_on_train_car()
+			queue_free()
+		else:
+			speed = 0

--- a/scenes/entities/car.gd.uid
+++ b/scenes/entities/car.gd.uid
@@ -1,0 +1,1 @@
+uid://h4voga0pd62

--- a/scenes/entities/car.tscn
+++ b/scenes/entities/car.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=3 format=3 uid="uid://ciqsnavw4c72n"]
+
+[ext_resource type="Script" uid="uid://h4voga0pd62" path="res://scenes/entities/car.gd" id="1_l37lr"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kpd8a"]
+bg_color = Color(0.183594, 0.183594, 0.183594, 1)
+
+[node name="car" type="PathFollow2D"]
+script = ExtResource("1_l37lr")
+
+[node name="Panel" type="Panel" parent="."]
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -20.5
+offset_top = -16.0
+offset_right = 20.5
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_styles/panel = SubResource("StyleBoxFlat_kpd8a")

--- a/scenes/entities/coaster_part.tscn13949271003.tmp
+++ b/scenes/entities/coaster_part.tscn13949271003.tmp
@@ -1,0 +1,23 @@
+[gd_scene load_steps=3 format=3 uid="uid://cy4mepircebey"]
+
+[ext_resource type="Script" uid="uid://dcp4881wiphnj" path="res://scenes/entities/coaster_part.gd" id="1_q0nch"]
+
+[sub_resource type="Curve2D" id="Curve2D_q0nch"]
+_data = {
+"points": PackedVector2Array(0, 0, 0, 0, -2, -1, 0, 0, 0, 0, 36, -150, 0, 0, 0, 0, 91, -173, 0, 0, 0, 0, 138, -168, 0, 0, 0, 0, 204, -4)
+}
+point_count = 5
+
+[node name="coaster_part" type="Node2D"]
+script = ExtResource("1_q0nch")
+
+[node name="art" type="Polygon2D" parent="."]
+color = Color(0.410156, 0.410156, 0.410156, 1)
+polygon = PackedVector2Array(-5, -2, 32, -147, 86, -177, 139, -170, 206, -5, 200, -2, 133, -163, 90, -169, 39, -142, 1, 2)
+
+[node name="coaster_path" type="Path2D" parent="."]
+curve = SubResource("Curve2D_q0nch")
+
+[node name="PathFollow2D" type="PathFollow2D" parent="coaster_path"]
+position = Vector2(-2, -1)
+rotation = -1.32109

--- a/scenes/entities/tracks/track_part_1.gd
+++ b/scenes/entities/tracks/track_part_1.gd
@@ -1,0 +1,60 @@
+extends Node2D
+class_name TrackPart
+
+# EXPORTED VARs
+@export var track_right:NodePath
+@export var is_starting_track:bool = false
+
+# GETTING NODES
+@onready var path_follow_2d: PathFollow2D = $coaster_path/PathFollow2D
+@onready var coaster_path: Path2D = $coaster_path
+
+# SCRIPT VARs
+var track_speed:float = 1
+var car_count:int = 5
+var grabbed:bool = false
+var grab_offset:Vector2 = Vector2.ZERO
+var track_cooldown:bool = false
+
+func _ready() -> void:
+	if is_starting_track:
+		# IF THIS TRACK IS THE FIRST ONE, SPAWN A CAR
+		for i in range(car_count):
+			grab_train_car(new_car())
+			# SLIGHT DELAY BETWEEN CARs
+			await get_tree().create_timer(0.5).timeout
+
+func _process(_delta: float) -> void:
+	if grabbed:
+		position = get_global_mouse_position() + grab_offset
+
+# RETURNS A NEW TRAIN CAR SCENE
+func new_car():
+	return load("res://scenes/entities/car.tscn").instantiate()
+
+# FOR A TRACK PEICE TO GRAB A TRAIN CAR
+func grab_train_car(train_car):
+	train_car.track_attached = self
+	coaster_path.add_child(train_car)
+
+# ALLOWS THIS SCENE TO PASS A NEW CAR TO THE NEXT TRACK
+func pass_on_train_car():
+	if track_right:
+		get_node(track_right).grab_train_car(new_car())
+
+func _on_track_end_area_entered(area: Area2D) -> void:
+	# GETS THE TRACK THAT IS IN PROXIMITY FROM AREA 2D
+	track_right = area.get_parent().get_path()
+
+func _on_track_end_area_exited(area: Area2D) -> void:
+	# IF THE TRACK CONNECTED MOVES AWAY, DISCONNECT IT
+	track_right = ""
+
+func _on_grab_detect_button_down() -> void:
+	# WHEN MOUSE DOWN SET GRABBED TO TRUE AND GET OFFSET
+	grab_offset = position - get_global_mouse_position()
+	grabbed = true
+
+func _on_grab_detect_button_up() -> void:
+	# WHEN MOUSE RELASED SET GRABBED TO FALSE
+	grabbed = false

--- a/scenes/entities/tracks/track_part_1.gd.uid
+++ b/scenes/entities/tracks/track_part_1.gd.uid
@@ -1,0 +1,1 @@
+uid://dcp4881wiphnj

--- a/scenes/entities/tracks/track_part_1.tscn
+++ b/scenes/entities/tracks/track_part_1.tscn
@@ -1,0 +1,53 @@
+[gd_scene load_steps=4 format=3 uid="uid://cy4mepircebey"]
+
+[ext_resource type="Script" uid="uid://dcp4881wiphnj" path="res://scenes/entities/tracks/track_part_1.gd" id="1_q0nch"]
+
+[sub_resource type="Curve2D" id="Curve2D_q0nch"]
+_data = {
+"points": PackedVector2Array(0, 0, 0, 0, -2, -1, 0, 0, 0, 0, 36, -150, 0, 0, 0, 0, 91, -173, 0, 0, 0, 0, 138, -168, 0, 0, 0, 0, 204, -4)
+}
+point_count = 5
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_oxk6s"]
+radius = 14.0357
+
+[node name="track_part_1" type="Node2D"]
+script = ExtResource("1_q0nch")
+
+[node name="grab_detect" type="Button" parent="."]
+modulate = Color(1, 1, 1, 0.454902)
+offset_top = -177.0
+offset_right = 197.0
+offset_bottom = 8.0
+focus_mode = 0
+
+[node name="art" type="Polygon2D" parent="."]
+color = Color(0.410156, 0.410156, 0.410156, 1)
+polygon = PackedVector2Array(-5, -2, 32, -147, 86, -177, 139, -170, 206, -5, 200, -2, 133, -163, 90, -169, 39, -142, 1, 2)
+
+[node name="coaster_path" type="Path2D" parent="."]
+curve = SubResource("Curve2D_q0nch")
+
+[node name="PathFollow2D" type="PathFollow2D" parent="coaster_path"]
+position = Vector2(-2, -1)
+rotation = -1.32109
+
+[node name="track_start" type="Area2D" parent="."]
+collision_layer = 16
+collision_mask = 32
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="track_start"]
+shape = SubResource("CircleShape2D_oxk6s")
+
+[node name="track_end" type="Area2D" parent="."]
+position = Vector2(202, -2)
+collision_layer = 32
+collision_mask = 16
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="track_end"]
+shape = SubResource("CircleShape2D_oxk6s")
+
+[connection signal="button_down" from="grab_detect" to="." method="_on_grab_detect_button_down"]
+[connection signal="button_up" from="grab_detect" to="." method="_on_grab_detect_button_up"]
+[connection signal="area_entered" from="track_end" to="." method="_on_track_end_area_entered"]
+[connection signal="area_exited" from="track_end" to="." method="_on_track_end_area_exited"]

--- a/scenes/entities/tracks/track_part_1.tscn15630051800.tmp
+++ b/scenes/entities/tracks/track_part_1.tscn15630051800.tmp
@@ -1,0 +1,44 @@
+[gd_scene load_steps=4 format=3 uid="uid://cy4mepircebey"]
+
+[ext_resource type="Script" uid="uid://dcp4881wiphnj" path="res://scenes/entities/tracks/track_part_1.gd" id="1_q0nch"]
+
+[sub_resource type="Curve2D" id="Curve2D_q0nch"]
+_data = {
+"points": PackedVector2Array(0, 0, 0, 0, -2, -1, 0, 0, 0, 0, 36, -150, 0, 0, 0, 0, 91, -173, 0, 0, 0, 0, 138, -168, 0, 0, 0, 0, 204, -4)
+}
+point_count = 5
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_oxk6s"]
+radius = 14.0357
+
+[node name="track_part_1" type="Node2D"]
+script = ExtResource("1_q0nch")
+
+[node name="art" type="Polygon2D" parent="."]
+color = Color(0.410156, 0.410156, 0.410156, 1)
+polygon = PackedVector2Array(-5, -2, 32, -147, 86, -177, 139, -170, 206, -5, 200, -2, 133, -163, 90, -169, 39, -142, 1, 2)
+
+[node name="coaster_path" type="Path2D" parent="."]
+curve = SubResource("Curve2D_q0nch")
+
+[node name="PathFollow2D" type="PathFollow2D" parent="coaster_path"]
+position = Vector2(-2, -1)
+rotation = -1.32109
+
+[node name="track_start" type="Area2D" parent="."]
+collision_layer = 16
+collision_mask = 32
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="track_start"]
+shape = SubResource("CircleShape2D_oxk6s")
+
+[node name="track_end" type="Area2D" parent="."]
+position = Vector2(202, -2)
+collision_layer = 32
+collision_mask = 16
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="track_end"]
+shape = SubResource("CircleShape2D_oxk6s")
+
+[connection signal="area_entered" from="track_end" to="." method="_on_track_end_area_entered"]
+[connection signal="area_exited" from="track_end" to="." method="_on_track_end_area_exited"]

--- a/scenes/maps/prelaunch_area.gd
+++ b/scenes/maps/prelaunch_area.gd
@@ -1,0 +1,1 @@
+extends Node2D

--- a/scenes/maps/prelaunch_area.gd.uid
+++ b/scenes/maps/prelaunch_area.gd.uid
@@ -1,0 +1,1 @@
+uid://dm30ouip10g0o

--- a/scenes/maps/prelaunch_area.tscn
+++ b/scenes/maps/prelaunch_area.tscn
@@ -1,0 +1,47 @@
+[gd_scene load_steps=3 format=3 uid="uid://crtg2aujnc5rl"]
+
+[ext_resource type="Script" uid="uid://dm30ouip10g0o" path="res://scenes/maps/prelaunch_area.gd" id="1_031nh"]
+[ext_resource type="PackedScene" uid="uid://cy4mepircebey" path="res://scenes/entities/tracks/track_part_1.tscn" id="2_8q4c4"]
+
+[node name="prelaunch_area" type="Node2D"]
+script = ExtResource("1_031nh")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="bg" type="ColorRect" parent="CanvasLayer"]
+visible = false
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.38269, 0.803514, 0.859375, 1)
+
+[node name="ground" type="ColorRect" parent="CanvasLayer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = 592.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.292969, 0.113931, 0.0354767, 1)
+
+[node name="groundgrass" type="ColorRect" parent="CanvasLayer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = 592.0
+offset_bottom = -36.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.388965, 0.902344, 0.264359, 1)
+
+[node name="coaster_part" parent="." instance=ExtResource("2_8q4c4")]
+position = Vector2(93, 579)
+is_starting_track = true
+
+[node name="coaster_part2" parent="." instance=ExtResource("2_8q4c4")]
+position = Vector2(302, 572)
+
+[node name="coaster_part3" parent="." instance=ExtResource("2_8q4c4")]
+position = Vector2(509, 572)

--- a/scenes/props/placeholder.txt
+++ b/scenes/props/placeholder.txt
@@ -1,0 +1,1 @@
+i put this here so its recognised as a path


### PR DESCRIPTION
Introduces initial scenes and scripts for coaster track parts and cars, including logic for spawning, attaching, and passing cars between tracks. Adds placeholder files for asset directories and sets up the prelaunch area scene with multiple track segments. Updates project settings for main scene and physics layer names.