### PR TITLE
Add train car launch system and track improvements

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="uid://crtg2aujnc5rl"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
 
+[autoload]
+
+GameData="*res://scenes/game_data.gd"
+
 [display]
 
 window/stretch/mode="canvas_items"

--- a/scenes/entities/car.gd
+++ b/scenes/entities/car.gd
@@ -2,16 +2,28 @@ extends PathFollow2D
 class_name Car
 
 var track_attached:TrackPart
-var speed:float
+var speed:float = -1
+var end_of_track:bool = false
 
 func _ready() -> void:
-	speed = track_attached.track_speed
+	if speed == -1:
+		speed = track_attached.track_speed
 
 func _process(delta: float) -> void:
 	progress_ratio += 0.2 * delta * speed
+	
+	if rotation_degrees > 10 and !end_of_track:
+		speed += 0.1 * delta
+		speed *= 1.01
+		
+	if rotation_degrees < -10 and !end_of_track:
+		speed -= 0.07 * delta
+		speed *= 0.99
+	
 	if progress_ratio >= 0.99:
-		if track_attached.track_right and track_attached.track_cooldown == false:
-			track_attached.pass_on_train_car()
+		if track_attached.track_right:
+			track_attached.pass_on_train_car(speed)
 			queue_free()
 		else:
 			speed = 0
+			end_of_track = true

--- a/scenes/entities/car.tscn
+++ b/scenes/entities/car.tscn
@@ -19,4 +19,5 @@ offset_top = -16.0
 offset_right = 20.5
 grow_horizontal = 2
 grow_vertical = 0
+mouse_filter = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_kpd8a")

--- a/scenes/entities/tracks/track_part_1.tscn
+++ b/scenes/entities/tracks/track_part_1.tscn
@@ -4,7 +4,7 @@
 
 [sub_resource type="Curve2D" id="Curve2D_q0nch"]
 _data = {
-"points": PackedVector2Array(0, 0, 0, 0, -2, -1, 0, 0, 0, 0, 36, -150, 0, 0, 0, 0, 91, -173, 0, 0, 0, 0, 138, -168, 0, 0, 0, 0, 204, -4)
+"points": PackedVector2Array(0, 0, 0, 0, -2, -1, 0, 0, 0, 0, 36, -150, 0, 0, 0, 0, 91, -173, 0, 0, 0, 0, 138, -168, 0, 0, 0, 0, 188, 1)
 }
 point_count = 5
 
@@ -17,37 +17,43 @@ script = ExtResource("1_q0nch")
 [node name="grab_detect" type="Button" parent="."]
 modulate = Color(1, 1, 1, 0.454902)
 offset_top = -177.0
-offset_right = 197.0
-offset_bottom = 8.0
+offset_right = 192.0
+offset_bottom = 15.0
 focus_mode = 0
 
 [node name="art" type="Polygon2D" parent="."]
 color = Color(0.410156, 0.410156, 0.410156, 1)
-polygon = PackedVector2Array(-5, -2, 32, -147, 86, -177, 139, -170, 206, -5, 200, -2, 133, -163, 90, -169, 39, -142, 1, 2)
+polygon = PackedVector2Array(-5, -2, 32, -147, 86, -177, 139, -170, 195, 0, 189, 3, 133, -163, 90, -169, 39, -142, 1, 2)
 
 [node name="coaster_path" type="Path2D" parent="."]
 curve = SubResource("Curve2D_q0nch")
 
-[node name="PathFollow2D" type="PathFollow2D" parent="coaster_path"]
+[node name="start" type="PathFollow2D" parent="coaster_path"]
 position = Vector2(-2, -1)
 rotation = -1.32109
 
-[node name="track_start" type="Area2D" parent="."]
+[node name="track_start" type="Area2D" parent="coaster_path/start"]
+rotation = 1.32109
 collision_layer = 16
 collision_mask = 32
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="track_start"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="coaster_path/start/track_start"]
 shape = SubResource("CircleShape2D_oxk6s")
 
-[node name="track_end" type="Area2D" parent="."]
-position = Vector2(202, -2)
+[node name="end" type="PathFollow2D" parent="coaster_path"]
+position = Vector2(188, 1)
+rotation = 1.28314
+progress = 437.432
+
+[node name="track_end" type="Area2D" parent="coaster_path/end"]
+rotation = 1.32109
 collision_layer = 32
 collision_mask = 16
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="track_end"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="coaster_path/end/track_end"]
 shape = SubResource("CircleShape2D_oxk6s")
 
 [connection signal="button_down" from="grab_detect" to="." method="_on_grab_detect_button_down"]
 [connection signal="button_up" from="grab_detect" to="." method="_on_grab_detect_button_up"]
-[connection signal="area_entered" from="track_end" to="." method="_on_track_end_area_entered"]
-[connection signal="area_exited" from="track_end" to="." method="_on_track_end_area_exited"]
+[connection signal="area_entered" from="coaster_path/end/track_end" to="." method="_on_track_end_area_entered"]
+[connection signal="area_exited" from="coaster_path/end/track_end" to="." method="_on_track_end_area_exited"]

--- a/scenes/game_data.gd
+++ b/scenes/game_data.gd
@@ -1,0 +1,3 @@
+extends Node
+
+signal launch_train_cars

--- a/scenes/game_data.gd.uid
+++ b/scenes/game_data.gd.uid
@@ -1,0 +1,1 @@
+uid://bwv5be62wbkgt

--- a/scenes/maps/prelaunch_area.gd
+++ b/scenes/maps/prelaunch_area.gd
@@ -1,1 +1,4 @@
 extends Node2D
+
+func _on_launch_pressed() -> void:
+	GameData.launch_train_cars.emit()

--- a/scenes/maps/prelaunch_area.tscn
+++ b/scenes/maps/prelaunch_area.tscn
@@ -15,6 +15,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 color = Color(0.38269, 0.803514, 0.859375, 1)
 
 [node name="ground" type="ColorRect" parent="CanvasLayer"]
@@ -24,6 +25,7 @@ anchor_bottom = 1.0
 offset_top = 592.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 color = Color(0.292969, 0.113931, 0.0354767, 1)
 
 [node name="groundgrass" type="ColorRect" parent="CanvasLayer"]
@@ -34,14 +36,34 @@ offset_top = 592.0
 offset_bottom = -36.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 color = Color(0.388965, 0.902344, 0.264359, 1)
+
+[node name="launch" type="Button" parent="CanvasLayer"]
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -65.0
+offset_top = 22.0
+offset_right = 65.0
+offset_bottom = 72.0
+grow_horizontal = 2
+text = "Launch"
 
 [node name="coaster_part" parent="." instance=ExtResource("2_8q4c4")]
 position = Vector2(93, 579)
 is_starting_track = true
 
 [node name="coaster_part2" parent="." instance=ExtResource("2_8q4c4")]
-position = Vector2(302, 572)
+position = Vector2(366, 518)
 
 [node name="coaster_part3" parent="." instance=ExtResource("2_8q4c4")]
-position = Vector2(509, 572)
+position = Vector2(721, 462)
+
+[node name="coaster_part4" parent="." instance=ExtResource("2_8q4c4")]
+position = Vector2(916, 326)
+
+[node name="coaster_part5" parent="." instance=ExtResource("2_8q4c4")]
+position = Vector2(864, 531)
+
+[connection signal="pressed" from="CanvasLayer/launch" to="." method="_on_launch_pressed"]


### PR DESCRIPTION
Introduces a GameData autoload singleton with a launch_train_cars signal to trigger car spawning. Refactors track and car logic for better speed handling, snapping, and car transfer between tracks. Updates scene files to support new launch button and improved track layout and snapping behavior.