### PR TITLE
Enhance pause menu UI with blur and custom buttons

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -66,6 +66,12 @@ prelaunch_interact={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
 ]
 }
+pause={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194306,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/scenes/UI/pause_menu.gd
+++ b/scenes/UI/pause_menu.gd
@@ -19,11 +19,9 @@ func pauseMenu():
 	paused = !paused
 	
 
-
 func _on_resume_pressed() -> void:
 	#main_scene.pauseMenu()
 	pass
-
 
 func _on_quit_pressed() -> void:
 	get_tree().quit()

--- a/scenes/UI/pause_menu.tscn
+++ b/scenes/UI/pause_menu.tscn
@@ -1,6 +1,14 @@
-[gd_scene load_steps=2 format=3 uid="uid://cfyi6llmyjhsv"]
+[gd_scene load_steps=5 format=3 uid="uid://co3scgrxi38i1"]
 
 [ext_resource type="Script" uid="uid://l1xt2hsig81s" path="res://scenes/UI/pause_menu.gd" id="1_qo2fb"]
+[ext_resource type="PackedScene" uid="uid://bklsq5dgkbhdd" path="res://scenes/UI/custom_button.tscn" id="2_bl585"]
+[ext_resource type="Shader" uid="uid://b2bye2xne3t0d" path="res://scenes/UI/blur_shader.gdshader" id="2_mko1u"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_feath"]
+shader = ExtResource("2_mko1u")
+shader_parameter/blur_amount = 0.988
+shader_parameter/mix_amount = 0.0
+shader_parameter/color_over = Color(0, 0, 0, 1)
 
 [node name="Pause" type="Control"]
 layout_mode = 3
@@ -11,19 +19,53 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_qo2fb")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-layout_mode = 0
-offset_left = 512.0
-offset_top = 261.0
-offset_right = 643.0
-offset_bottom = 394.0
+[node name="bg" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.230469, 0.230469, 0.230469, 0.458824)
 
-[node name="Resume" type="Button" parent="VBoxContainer"]
+[node name="blur_bg" type="ColorRect" parent="bg"]
+show_behind_parent = true
+material = SubResource("ShaderMaterial_feath")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -161.5
+offset_top = -57.5
+offset_right = 161.5
+offset_bottom = 57.5
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 15
+
+[node name="Resume" parent="VBoxContainer" instance=ExtResource("2_bl585")]
+custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 3
 text = "Resume"
 
-[node name="quit" type="Button" parent="VBoxContainer"]
+[node name="quit" parent="VBoxContainer" instance=ExtResource("2_bl585")]
+custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 3
 text = "Quit"
 
 [connection signal="pressed" from="VBoxContainer/Resume" to="." method="_on_resume_pressed"]


### PR DESCRIPTION
Added a blur shader background and semi-transparent overlay to the pause menu for improved visual clarity. Replaced default buttons with custom button scenes and adjusted layout for better centering. Also added a new 'pause' input action in project settings.