### PR TITLE
Cutscene creation

### DIFF
--- a/scenes/UI/cutscene_frames/delivery_cutscene_2.tres
+++ b/scenes/UI/cutscene_frames/delivery_cutscene_2.tres
@@ -1,0 +1,11 @@
+[gd_resource type="Resource" script_class="CutsceneFrames" load_steps=5 format=3 uid="uid://p506kgo0gymx"]
+
+[ext_resource type="Texture2D" uid="uid://com5dtefq0w0l" path="res://assets/cut_scenes/delivery_cutscenes/delivery_2/delivery_2_1.png" id="1_i2s8h"]
+[ext_resource type="Script" uid="uid://bwl7smwceha2g" path="res://scenes/UI/cutscene_frames.gd" id="1_lxu10"]
+[ext_resource type="Texture2D" uid="uid://330mexddah3w" path="res://assets/cut_scenes/delivery_cutscenes/delivery_2/delivery_2_2.png" id="2_bpd1y"]
+[ext_resource type="Texture2D" uid="uid://dkohq6bxj12mv" path="res://assets/cut_scenes/delivery_cutscenes/delivery_2/delivery_2_3.png" id="3_1ujj7"]
+
+[resource]
+script = ExtResource("1_lxu10")
+frames = Array[CompressedTexture2D]([ExtResource("1_i2s8h"), ExtResource("2_bpd1y"), ExtResource("3_1ujj7")])
+metadata/_custom_type_script = "uid://bwl7smwceha2g"

--- a/scenes/UI/cutscene_frames/delivery_cutscene_3.tres
+++ b/scenes/UI/cutscene_frames/delivery_cutscene_3.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" script_class="CutsceneFrames" load_steps=7 format=3 uid="uid://baeai2fmom6uk"]
+
+[ext_resource type="Script" uid="uid://bwl7smwceha2g" path="res://scenes/UI/cutscene_frames.gd" id="1_2d6is"]
+[ext_resource type="Texture2D" uid="uid://dwk3ojri5ckvf" path="res://assets/cut_scenes/delivery_cutscenes/delivery_3/delivery_3_1.png" id="1_4b3hr"]
+[ext_resource type="Texture2D" uid="uid://o8q3k75iolc1" path="res://assets/cut_scenes/delivery_cutscenes/delivery_3/delivery_3_2.png" id="2_q307v"]
+[ext_resource type="Texture2D" uid="uid://b4hxnvjjq8p6v" path="res://assets/cut_scenes/delivery_cutscenes/delivery_3/delivery_3_3.png" id="3_sx8td"]
+[ext_resource type="Texture2D" uid="uid://cw30j6sym3xf" path="res://assets/cut_scenes/delivery_cutscenes/delivery_3/delivery_3_4.png" id="4_l11id"]
+[ext_resource type="Texture2D" uid="uid://4851rwvq7nvy" path="res://assets/cut_scenes/delivery_cutscenes/delivery_3/delivery_3_5.png" id="5_38wwm"]
+
+[resource]
+script = ExtResource("1_2d6is")
+frames = Array[CompressedTexture2D]([ExtResource("1_4b3hr"), ExtResource("2_q307v"), ExtResource("3_sx8td"), ExtResource("4_l11id"), ExtResource("5_38wwm")])
+metadata/_custom_type_script = "uid://bwl7smwceha2g"

--- a/scenes/UI/cutscene_frames/delivery_cutscene_4.tres
+++ b/scenes/UI/cutscene_frames/delivery_cutscene_4.tres
@@ -1,0 +1,11 @@
+[gd_resource type="Resource" script_class="CutsceneFrames" load_steps=5 format=3 uid="uid://bdxcir3hc2e5a"]
+
+[ext_resource type="Script" uid="uid://bwl7smwceha2g" path="res://scenes/UI/cutscene_frames.gd" id="1_eu4lm"]
+[ext_resource type="Texture2D" uid="uid://d012cv40364u1" path="res://assets/cut_scenes/delivery_cutscenes/delivery_4/delivery_4_1.png" id="1_pxglp"]
+[ext_resource type="Texture2D" uid="uid://d1o26vhoc24hk" path="res://assets/cut_scenes/delivery_cutscenes/delivery_4/delivery_4_2.png" id="2_refwn"]
+[ext_resource type="Texture2D" uid="uid://bnit4prgq47t2" path="res://assets/cut_scenes/delivery_cutscenes/delivery_4/delivery_4_3.png" id="3_lhrtk"]
+
+[resource]
+script = ExtResource("1_eu4lm")
+frames = Array[CompressedTexture2D]([ExtResource("1_pxglp"), ExtResource("2_refwn"), ExtResource("3_lhrtk")])
+metadata/_custom_type_script = "uid://bwl7smwceha2g"

--- a/scenes/UI/cutscene_frames/delivery_cutscene_5.tres
+++ b/scenes/UI/cutscene_frames/delivery_cutscene_5.tres
@@ -1,0 +1,11 @@
+[gd_resource type="Resource" script_class="CutsceneFrames" load_steps=5 format=3 uid="uid://cnbso0ok8vg1m"]
+
+[ext_resource type="Script" uid="uid://bwl7smwceha2g" path="res://scenes/UI/cutscene_frames.gd" id="1_8qbxh"]
+[ext_resource type="Texture2D" uid="uid://opspj3tu2gdo" path="res://assets/cut_scenes/delivery_cutscenes/delivery_5/delivery_5_1.png" id="1_so8eh"]
+[ext_resource type="Texture2D" uid="uid://kirlvocrgq1f" path="res://assets/cut_scenes/delivery_cutscenes/delivery_5/delivery_5_2.png" id="2_uv1k3"]
+[ext_resource type="Texture2D" uid="uid://bias1wqjqaid6" path="res://assets/cut_scenes/delivery_cutscenes/delivery_5/delivery_5_3.png" id="3_x46na"]
+
+[resource]
+script = ExtResource("1_8qbxh")
+frames = Array[CompressedTexture2D]([ExtResource("1_so8eh"), ExtResource("2_uv1k3"), ExtResource("3_x46na")])
+metadata/_custom_type_script = "uid://bwl7smwceha2g"

--- a/scenes/UI/cutscene_frames/ending_cutscene.tres
+++ b/scenes/UI/cutscene_frames/ending_cutscene.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="CutsceneFrames" load_steps=13 format=3 uid="uid://6mp7i02r35wm"]
+
+[ext_resource type="Script" uid="uid://bwl7smwceha2g" path="res://scenes/UI/cutscene_frames.gd" id="1_4ekda"]
+[ext_resource type="Texture2D" uid="uid://dfngs6d50nhbg" path="res://assets/cut_scenes/ending/ending_1.png" id="1_gtxt8"]
+[ext_resource type="Texture2D" uid="uid://ckcd776rc2k7n" path="res://assets/cut_scenes/ending/ending_2.png" id="2_miung"]
+[ext_resource type="Texture2D" uid="uid://c4yxvopy1xxsi" path="res://assets/cut_scenes/ending/ending_3.png" id="3_hoeu1"]
+[ext_resource type="Texture2D" uid="uid://cbiu7qarp6dw5" path="res://assets/cut_scenes/ending/ending_4.png" id="4_hrgca"]
+[ext_resource type="Texture2D" uid="uid://b6a0058pde3ly" path="res://assets/cut_scenes/ending/ending_5.png" id="5_5mx16"]
+[ext_resource type="Texture2D" uid="uid://xmlk6vx22csi" path="res://assets/cut_scenes/ending/ending_6.png" id="6_3p3ek"]
+[ext_resource type="Texture2D" uid="uid://bfdylr30d74ak" path="res://assets/cut_scenes/ending/ending_7.png" id="7_mkbj2"]
+[ext_resource type="Texture2D" uid="uid://djus43rafr4f8" path="res://assets/cut_scenes/ending/ending_8.png" id="8_683x7"]
+[ext_resource type="Texture2D" uid="uid://c8ti26dohdil4" path="res://assets/cut_scenes/ending/ending_9.png" id="9_fd77x"]
+[ext_resource type="Texture2D" uid="uid://bseumcibuqqe8" path="res://assets/cut_scenes/ending/ending_10.png" id="10_74pq4"]
+[ext_resource type="Texture2D" uid="uid://gijlbu6ub87f" path="res://assets/cut_scenes/ending/ending_11.png" id="11_06ugp"]
+
+[resource]
+script = ExtResource("1_4ekda")
+frames = Array[CompressedTexture2D]([ExtResource("1_gtxt8"), ExtResource("2_miung"), ExtResource("3_hoeu1"), ExtResource("4_hrgca"), ExtResource("5_5mx16"), ExtResource("6_3p3ek"), ExtResource("7_mkbj2"), ExtResource("8_683x7"), ExtResource("9_fd77x"), ExtResource("10_74pq4"), ExtResource("11_06ugp")])
+metadata/_custom_type_script = "uid://bwl7smwceha2g"

--- a/scenes/UI/cutscene_frames/office_cutscene_2.tres
+++ b/scenes/UI/cutscene_frames/office_cutscene_2.tres
@@ -1,0 +1,14 @@
+[gd_resource type="Resource" script_class="CutsceneFrames" load_steps=8 format=3 uid="uid://ceobq0ggjig30"]
+
+[ext_resource type="Texture2D" uid="uid://c3lrepomtimhd" path="res://assets/cut_scenes/office_cutscenes/office_2/office_2_1.png" id="1_77ffe"]
+[ext_resource type="Script" uid="uid://bwl7smwceha2g" path="res://scenes/UI/cutscene_frames.gd" id="1_dcybc"]
+[ext_resource type="Texture2D" uid="uid://dgmlraxs7yxmw" path="res://assets/cut_scenes/office_cutscenes/office_2/office_2_2.png" id="2_ffda3"]
+[ext_resource type="Texture2D" uid="uid://bh1ve58pv361t" path="res://assets/cut_scenes/office_cutscenes/office_2/office_2_3.png" id="3_mhy8i"]
+[ext_resource type="Texture2D" uid="uid://d04gne801akw7" path="res://assets/cut_scenes/office_cutscenes/office_2/office_2_4.png" id="4_atl6g"]
+[ext_resource type="Texture2D" uid="uid://bw34217p84gqt" path="res://assets/cut_scenes/office_cutscenes/office_2/office_2_5.png" id="5_rhqya"]
+[ext_resource type="Texture2D" uid="uid://bdhhrqtyf71e7" path="res://assets/cut_scenes/office_cutscenes/office_2/office_2_6.png" id="6_30brm"]
+
+[resource]
+script = ExtResource("1_dcybc")
+frames = Array[CompressedTexture2D]([ExtResource("1_77ffe"), ExtResource("2_ffda3"), ExtResource("3_mhy8i"), ExtResource("4_atl6g"), ExtResource("5_rhqya"), ExtResource("6_30brm")])
+metadata/_custom_type_script = "uid://bwl7smwceha2g"

--- a/scenes/UI/cutscene_frames/office_cutscene_3.tres
+++ b/scenes/UI/cutscene_frames/office_cutscene_3.tres
@@ -1,0 +1,14 @@
+[gd_resource type="Resource" script_class="CutsceneFrames" load_steps=8 format=3 uid="uid://76dpdwx6kn0b"]
+
+[ext_resource type="Script" uid="uid://bwl7smwceha2g" path="res://scenes/UI/cutscene_frames.gd" id="1_cqdyn"]
+[ext_resource type="Texture2D" uid="uid://drcff03x00ruu" path="res://assets/cut_scenes/office_cutscenes/office_3/office_3_1.png" id="1_lxrij"]
+[ext_resource type="Texture2D" uid="uid://w43irunmudck" path="res://assets/cut_scenes/office_cutscenes/office_3/office_3_2.png" id="2_5x15d"]
+[ext_resource type="Texture2D" uid="uid://yjguebf0g4yg" path="res://assets/cut_scenes/office_cutscenes/office_3/office_3_3.png" id="3_pga4b"]
+[ext_resource type="Texture2D" uid="uid://d373v7o1hnxpk" path="res://assets/cut_scenes/office_cutscenes/office_3/office_3_4.png" id="4_3vs7c"]
+[ext_resource type="Texture2D" uid="uid://gbg367iquu1n" path="res://assets/cut_scenes/office_cutscenes/office_3/office_3_5.png" id="5_lcly8"]
+[ext_resource type="Texture2D" uid="uid://cbxosf00piw8m" path="res://assets/cut_scenes/office_cutscenes/office_3/office_3_6.png" id="6_82t1j"]
+
+[resource]
+script = ExtResource("1_cqdyn")
+frames = Array[CompressedTexture2D]([ExtResource("1_lxrij"), ExtResource("2_5x15d"), ExtResource("3_pga4b"), ExtResource("4_3vs7c"), ExtResource("5_lcly8"), ExtResource("6_82t1j")])
+metadata/_custom_type_script = "uid://bwl7smwceha2g"

--- a/scenes/UI/cutscene_frames/office_cutscene_4.tres
+++ b/scenes/UI/cutscene_frames/office_cutscene_4.tres
@@ -1,0 +1,14 @@
+[gd_resource type="Resource" script_class="CutsceneFrames" load_steps=8 format=3 uid="uid://c3oe5qs77v6yn"]
+
+[ext_resource type="Texture2D" uid="uid://c7b08hicj8paw" path="res://assets/cut_scenes/office_cutscenes/office_4/office_4_1.png" id="1_1ngeq"]
+[ext_resource type="Script" uid="uid://bwl7smwceha2g" path="res://scenes/UI/cutscene_frames.gd" id="1_jwh72"]
+[ext_resource type="Texture2D" uid="uid://ccxc3484wutak" path="res://assets/cut_scenes/office_cutscenes/office_4/office_4_2.png" id="2_nrefu"]
+[ext_resource type="Texture2D" uid="uid://rel2xmvb7vxe" path="res://assets/cut_scenes/office_cutscenes/office_4/office_4_3.png" id="3_krd1v"]
+[ext_resource type="Texture2D" uid="uid://cbdht44ltr82u" path="res://assets/cut_scenes/office_cutscenes/office_4/office_4_4.png" id="4_oh2mr"]
+[ext_resource type="Texture2D" uid="uid://dgimwdlv6ggn3" path="res://assets/cut_scenes/office_cutscenes/office_4/office_4_5.png" id="5_iwmc8"]
+[ext_resource type="Texture2D" uid="uid://cs02gvk6c4gxb" path="res://assets/cut_scenes/office_cutscenes/office_4/office_4_6.png" id="6_qr6jd"]
+
+[resource]
+script = ExtResource("1_jwh72")
+frames = Array[CompressedTexture2D]([ExtResource("1_1ngeq"), ExtResource("2_nrefu"), ExtResource("3_krd1v"), ExtResource("4_oh2mr"), ExtResource("5_iwmc8"), ExtResource("6_qr6jd")])
+metadata/_custom_type_script = "uid://bwl7smwceha2g"

--- a/scenes/UI/cutscene_frames/office_cutscene_5.tres
+++ b/scenes/UI/cutscene_frames/office_cutscene_5.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="CutsceneFrames" load_steps=6 format=3 uid="uid://b5sf2n2gry3p4"]
+
+[ext_resource type="Script" uid="uid://bwl7smwceha2g" path="res://scenes/UI/cutscene_frames.gd" id="1_b2fi4"]
+[ext_resource type="Texture2D" uid="uid://dwp8rs3spmcoa" path="res://assets/cut_scenes/office_cutscenes/office_5/office_5_1.png" id="1_doimg"]
+[ext_resource type="Texture2D" uid="uid://mh3xx7uo0ybw" path="res://assets/cut_scenes/office_cutscenes/office_5/office_5_2.png" id="2_ucjgp"]
+[ext_resource type="Texture2D" uid="uid://bimwr164bovy7" path="res://assets/cut_scenes/office_cutscenes/office_5/office_5_3.png" id="3_va78g"]
+[ext_resource type="Texture2D" uid="uid://ds37b62dpp0em" path="res://assets/cut_scenes/office_cutscenes/office_5/office_5_4.png" id="4_f07p2"]
+
+[resource]
+script = ExtResource("1_b2fi4")
+frames = Array[CompressedTexture2D]([ExtResource("1_doimg"), ExtResource("2_ucjgp"), ExtResource("3_va78g"), ExtResource("4_f07p2")])
+metadata/_custom_type_script = "uid://bwl7smwceha2g"

--- a/scenes/UI/cutscenes/cutscene_template.tscn
+++ b/scenes/UI/cutscenes/cutscene_template.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=5 format=3 uid="uid://b7eid8e6fpbqd"]
+
+[ext_resource type="PackedScene" uid="uid://dtwwhoynn664" path="res://scenes/UI/cutscene_manager.tscn" id="1_pqx1v"]
+[ext_resource type="PackedScene" uid="uid://debaeg15rk26a" path="res://scenes/maps/level1.tscn" id="2_cp54q"]
+[ext_resource type="Resource" uid="uid://2yjl463oqpgm" path="res://scenes/UI/cutscene_frames/first_cutscene.tres" id="3_1erjr"]
+[ext_resource type="AudioStream" uid="uid://bqjvdsqa3d3nl" path="res://assets/music/Deli's Theme.mp3" id="4_go7w6"]
+
+[node name="cutscene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="cutscene_manager" parent="." instance=ExtResource("1_pqx1v")]
+layout_mode = 1
+finished_action = 0
+change_scene_to = ExtResource("2_cp54q")
+cut_scene = ExtResource("3_1erjr")
+
+[node name="Deli\'sTheme" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("4_go7w6")
+autoplay = true

--- a/scenes/UI/cutscenes/delivery_cutscene_2.tscn
+++ b/scenes/UI/cutscenes/delivery_cutscene_2.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=5 format=3 uid="uid://bygddmajg65f7"]
+
+[ext_resource type="PackedScene" uid="uid://dtwwhoynn664" path="res://scenes/UI/cutscene_manager.tscn" id="1_vc6r7"]
+[ext_resource type="PackedScene" uid="uid://debaeg15rk26a" path="res://scenes/maps/level1.tscn" id="2_7vm3o"]
+[ext_resource type="Resource" uid="uid://p506kgo0gymx" path="res://scenes/UI/cutscene_frames/delivery_cutscene_2.tres" id="3_vc6r7"]
+[ext_resource type="AudioStream" uid="uid://bqjvdsqa3d3nl" path="res://assets/music/Deli's Theme.mp3" id="4_1sblc"]
+
+[node name="delivery_cutscene_2" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="cutscene_manager" parent="." instance=ExtResource("1_vc6r7")]
+layout_mode = 1
+finished_action = 0
+change_scene_to = ExtResource("2_7vm3o")
+cut_scene = ExtResource("3_vc6r7")
+
+[node name="Deli\'sTheme" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("4_1sblc")
+autoplay = true

--- a/scenes/UI/cutscenes/delivery_cutscene_3.tscn
+++ b/scenes/UI/cutscenes/delivery_cutscene_3.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=5 format=3 uid="uid://bs41sbb75t08j"]
+
+[ext_resource type="PackedScene" uid="uid://dtwwhoynn664" path="res://scenes/UI/cutscene_manager.tscn" id="1_d2nrw"]
+[ext_resource type="PackedScene" uid="uid://debaeg15rk26a" path="res://scenes/maps/level1.tscn" id="2_p5r1c"]
+[ext_resource type="Resource" uid="uid://baeai2fmom6uk" path="res://scenes/UI/cutscene_frames/delivery_cutscene_3.tres" id="3_3nl2m"]
+[ext_resource type="AudioStream" uid="uid://bqjvdsqa3d3nl" path="res://assets/music/Deli's Theme.mp3" id="4_i6s2j"]
+
+[node name="delivery_cutscene_3" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="cutscene_manager" parent="." instance=ExtResource("1_d2nrw")]
+layout_mode = 1
+finished_action = 0
+change_scene_to = ExtResource("2_p5r1c")
+cut_scene = ExtResource("3_3nl2m")
+
+[node name="Deli\'sTheme" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("4_i6s2j")
+autoplay = true

--- a/scenes/UI/cutscenes/delivery_cutscene_4.tscn
+++ b/scenes/UI/cutscenes/delivery_cutscene_4.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=5 format=3 uid="uid://8l7lqsmmb11f"]
+
+[ext_resource type="PackedScene" uid="uid://dtwwhoynn664" path="res://scenes/UI/cutscene_manager.tscn" id="1_rd31q"]
+[ext_resource type="PackedScene" uid="uid://debaeg15rk26a" path="res://scenes/maps/level1.tscn" id="2_judcx"]
+[ext_resource type="AudioStream" uid="uid://bqjvdsqa3d3nl" path="res://assets/music/Deli's Theme.mp3" id="3_cuwfv"]
+[ext_resource type="Resource" uid="uid://bdxcir3hc2e5a" path="res://scenes/UI/cutscene_frames/delivery_cutscene_4.tres" id="3_judcx"]
+
+[node name="delivery_cutscene_4" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="cutscene_manager" parent="." instance=ExtResource("1_rd31q")]
+layout_mode = 1
+finished_action = 0
+change_scene_to = ExtResource("2_judcx")
+cut_scene = ExtResource("3_judcx")
+
+[node name="Deli\'sTheme" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("3_cuwfv")
+autoplay = true

--- a/scenes/UI/cutscenes/delivery_cutscene_5.tscn
+++ b/scenes/UI/cutscenes/delivery_cutscene_5.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=5 format=3 uid="uid://dc7oqxoslae4s"]
+
+[ext_resource type="PackedScene" uid="uid://dtwwhoynn664" path="res://scenes/UI/cutscene_manager.tscn" id="1_yyeat"]
+[ext_resource type="PackedScene" uid="uid://debaeg15rk26a" path="res://scenes/maps/level1.tscn" id="2_cj46u"]
+[ext_resource type="Resource" uid="uid://cnbso0ok8vg1m" path="res://scenes/UI/cutscene_frames/delivery_cutscene_5.tres" id="3_cj46u"]
+[ext_resource type="AudioStream" uid="uid://bqjvdsqa3d3nl" path="res://assets/music/Deli's Theme.mp3" id="3_pyb1f"]
+
+[node name="delivery_cutscene_5" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="cutscene_manager" parent="." instance=ExtResource("1_yyeat")]
+layout_mode = 1
+finished_action = 0
+change_scene_to = ExtResource("2_cj46u")
+cut_scene = ExtResource("3_cj46u")
+
+[node name="Deli\'sTheme" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("3_pyb1f")
+autoplay = true

--- a/scenes/UI/cutscenes/ending_cutscene.tscn
+++ b/scenes/UI/cutscenes/ending_cutscene.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=5 format=3 uid="uid://cdaug42xggnai"]
+
+[ext_resource type="PackedScene" uid="uid://dtwwhoynn664" path="res://scenes/UI/cutscene_manager.tscn" id="1_yyeat"]
+[ext_resource type="PackedScene" uid="uid://debaeg15rk26a" path="res://scenes/maps/level1.tscn" id="2_cj46u"]
+[ext_resource type="Resource" uid="uid://6mp7i02r35wm" path="res://scenes/UI/cutscene_frames/ending_cutscene.tres" id="3_cj46u"]
+[ext_resource type="AudioStream" uid="uid://bqjvdsqa3d3nl" path="res://assets/music/Deli's Theme.mp3" id="3_pyb1f"]
+
+[node name="ending_cutscene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="cutscene_manager" parent="." instance=ExtResource("1_yyeat")]
+layout_mode = 1
+finished_action = 0
+change_scene_to = ExtResource("2_cj46u")
+cut_scene = ExtResource("3_cj46u")
+
+[node name="Deli\'sTheme" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("3_pyb1f")
+autoplay = true

--- a/scenes/UI/cutscenes/office_cutscene_2.tscn
+++ b/scenes/UI/cutscenes/office_cutscene_2.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=5 format=3 uid="uid://cyloavqf1ecl4"]
+
+[ext_resource type="PackedScene" uid="uid://dtwwhoynn664" path="res://scenes/UI/cutscene_manager.tscn" id="1_bveqf"]
+[ext_resource type="PackedScene" uid="uid://debaeg15rk26a" path="res://scenes/maps/level1.tscn" id="2_kmvhd"]
+[ext_resource type="Resource" uid="uid://ceobq0ggjig30" path="res://scenes/UI/cutscene_frames/office_cutscene_2.tres" id="3_pqnr7"]
+[ext_resource type="AudioStream" uid="uid://bqjvdsqa3d3nl" path="res://assets/music/Deli's Theme.mp3" id="4_eukqm"]
+
+[node name="office_cutscene_2" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="cutscene_manager" parent="." instance=ExtResource("1_bveqf")]
+layout_mode = 1
+finished_action = 0
+change_scene_to = ExtResource("2_kmvhd")
+cut_scene = ExtResource("3_pqnr7")
+
+[node name="Deli\'sTheme" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("4_eukqm")
+autoplay = true

--- a/scenes/UI/cutscenes/office_cutscene_3.tscn
+++ b/scenes/UI/cutscenes/office_cutscene_3.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=5 format=3 uid="uid://d17fubcu0i131"]
+
+[ext_resource type="PackedScene" uid="uid://dtwwhoynn664" path="res://scenes/UI/cutscene_manager.tscn" id="1_f1l8m"]
+[ext_resource type="PackedScene" uid="uid://debaeg15rk26a" path="res://scenes/maps/level1.tscn" id="2_b8fu3"]
+[ext_resource type="Resource" uid="uid://76dpdwx6kn0b" path="res://scenes/UI/cutscene_frames/office_cutscene_3.tres" id="3_f1l8m"]
+[ext_resource type="AudioStream" uid="uid://bqjvdsqa3d3nl" path="res://assets/music/Deli's Theme.mp3" id="4_0qatn"]
+
+[node name="office_cutscene_3" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="cutscene_manager" parent="." instance=ExtResource("1_f1l8m")]
+layout_mode = 1
+finished_action = 0
+change_scene_to = ExtResource("2_b8fu3")
+cut_scene = ExtResource("3_f1l8m")
+
+[node name="Deli\'sTheme" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("4_0qatn")
+autoplay = true

--- a/scenes/UI/cutscenes/office_cutscene_4.tscn
+++ b/scenes/UI/cutscenes/office_cutscene_4.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=5 format=3 uid="uid://qj3jl4m0k1jm"]
+
+[ext_resource type="PackedScene" uid="uid://dtwwhoynn664" path="res://scenes/UI/cutscene_manager.tscn" id="1_i15ck"]
+[ext_resource type="PackedScene" uid="uid://debaeg15rk26a" path="res://scenes/maps/level1.tscn" id="2_a8qy8"]
+[ext_resource type="Resource" uid="uid://c3oe5qs77v6yn" path="res://scenes/UI/cutscene_frames/office_cutscene_4.tres" id="3_1q1u7"]
+[ext_resource type="AudioStream" uid="uid://bqjvdsqa3d3nl" path="res://assets/music/Deli's Theme.mp3" id="4_1trni"]
+
+[node name="office_cutscene_4" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="cutscene_manager" parent="." instance=ExtResource("1_i15ck")]
+layout_mode = 1
+finished_action = 0
+change_scene_to = ExtResource("2_a8qy8")
+cut_scene = ExtResource("3_1q1u7")
+
+[node name="Deli\'sTheme" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("4_1trni")
+autoplay = true

--- a/scenes/UI/cutscenes/office_cutscene_5.tscn
+++ b/scenes/UI/cutscenes/office_cutscene_5.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=5 format=3 uid="uid://dqe7kckf2ma0d"]
+
+[ext_resource type="PackedScene" uid="uid://dtwwhoynn664" path="res://scenes/UI/cutscene_manager.tscn" id="1_2bfrt"]
+[ext_resource type="PackedScene" uid="uid://debaeg15rk26a" path="res://scenes/maps/level1.tscn" id="2_gf5ki"]
+[ext_resource type="Resource" uid="uid://b5sf2n2gry3p4" path="res://scenes/UI/cutscene_frames/office_cutscene_5.tres" id="3_gf5ki"]
+[ext_resource type="AudioStream" uid="uid://bqjvdsqa3d3nl" path="res://assets/music/Deli's Theme.mp3" id="3_k2yt2"]
+
+[node name="office_cutscene_5" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="cutscene_manager" parent="." instance=ExtResource("1_2bfrt")]
+layout_mode = 1
+finished_action = 0
+change_scene_to = ExtResource("2_gf5ki")
+cut_scene = ExtResource("3_gf5ki")
+
+[node name="Deli\'sTheme" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("3_k2yt2")
+autoplay = true


### PR DESCRIPTION
Following the established model for cutscene creation: 

- I created a .tres resource for each cutscene.
- Then added them into the corresponding "cutscene" scene, as a resource inside its respective cutscene_manager instance. 

Scenes produced by myself were notated "office_cutscene_X" for cutscenes that start a level, and "delivery_cutscene_X*" for ones after the level.

As the cutscenes were all derived from "cutscene_1" (the games intro), "Deli's theme" is the music assigned to them all. Pull requesting anyway, in case they are needed as is. I didn't want to make an artistic decision about audio without approval. 